### PR TITLE
Turn off usbser drivers on Windows 10

### DIFF
--- a/adafruit_drivers.nsi
+++ b/adafruit_drivers.nsi
@@ -21,9 +21,9 @@ VIAddVersionKey /LANG=1033 "ProductName" "Adafruit Board Drivers"
 VIAddVersionKey /LANG=1033 "CompanyName" "Adafruit Industries"
 VIAddVersionKey /LANG=1033 "LegalCopyright" "Adafruit Industries"
 VIAddVersionKey /LANG=1033 "FileDescription" "All in one installer for Adafruit's board drivers."
-VIAddVersionKey /LANG=1033 "FileVersion" "1.0.0"
-VIProductVersion "1.0.0.0"
-VIFileVersion "1.0.0.0"
+VIAddVersionKey /LANG=1033 "FileVersion" "1.1.0"
+VIProductVersion "1.1.0.0"
+VIFileVersion "1.1.0.0"
 
 # Define variables used in sections.
 Var dpinst   # Will hold the path and name of dpinst being used (x86 or x64).
@@ -66,23 +66,23 @@ Section
   ${EndIf}
 SectionEnd
 
-Section "Feather 32u4"
-  # Use dpisnt to install the driver.
+Section "Feather 32u4" FEATHER_32U4
+  # Use dpinst to install the driver.
   # Note the following options are specified:
   #  /sw = silent mode, hide the installer but NOT the OS prompts (critical!)
   #  /path = path to directory with driver data
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_32u4"'
 SectionEnd
 
-Section "Feather M0"
+Section "Feather M0" FEATHER_M0
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_M0"'
 SectionEnd
 
-Section "Feather M0 Express"
+Section "Feather M0 Express" FEATHER_M0_EXPRESS
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_M0_Express"'
 SectionEnd
 
-Section "Metro M0 Express"
+Section "Metro M0 Express" METRO_M0_EXPRESS
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Metro_M0_Express"'
 SectionEnd
 
@@ -91,15 +91,18 @@ Section "Feather WICED"
   # Install all three drivers (each _must_ be in its own directory or
   # dpinst will silently fail!).
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_WICED"'
-  ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_WICED_CDC"'
+  # Don't install CDC driver on Windows 10, but do install the other drivers for WICED.
+  ${IfNot} ${AtLeastWin10}
+    ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_WICED_CDC"'
+  ${EndIf}
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Feather_WICED_DFU"'
 SectionEnd
 
-Section "Flora"
+Section "Flora" FLORA
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_Flora"'
 SectionEnd
 
-Section "Circuit Playground"
+Section "Circuit Playground" CIRCUIT_PLAYGROUND
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Adafruit_CircuitPlayground"'
 SectionEnd
 
@@ -107,7 +110,7 @@ Section "Trinket / Pro Trinket / Gemma (USBtinyISP)"
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\USBtinyISP"'
 SectionEnd
 
-Section /o "Arduino Gemma"
+Section /o "Arduino Gemma" ARDUINO_GEMMA
   ExecWait '"$dpinst" /sw /path "$INSTDIR\Drivers\Arduino_Gemma"'
 SectionEnd
 
@@ -133,7 +136,32 @@ Section /o "Metro 328 / Metro Mini 328 (FTDI VCP and CP210X)"
   ${EndIf}
 SectionEnd
 
-Section /o "Bluefruit LE Micro (PJRC CDC)"
+Section /o "Bluefruit LE Micro (PJRC CDC)" BLUEFRUIT_LE_MICRO
+  # PJRC CDC is not needed for Windows 10. The installer checks for Win10 and does nothing.
   # PJRC CDC has its own installer so just invoke that executable.
   ExecWait "$INSTDIR\Drivers\PJRC_CDC\PJRC CDC serial_install.exe"
 SectionEnd
+
+# Unselect, disable, and hide the given section.
+!macro HideSectionMacro SectionId
+  SectionSetFlags ${SectionId} ${SF_RO}
+  SectionSetText ${SectionId} ""
+!macroend
+
+!define HideSection '!insertMacro HideSectionMacro'
+
+Function .onInit
+  # Hide all drivers that aren't needed in Windows 10.
+  ${If} ${AtLeastWin10}
+    ${HideSection} ${FEATHER_32U4}
+    ${HideSection} ${FEATHER_M0}
+    ${HideSection} ${FEATHER_M0_EXPRESS}
+    ${HideSection} ${METRO_M0_EXPRESS}
+    ${HideSection} ${FLORA}
+    ${HideSection} ${METRO_M0_EXPRESS}
+    ${HideSection} ${FLORA}
+    ${HideSection} ${CIRCUIT_PLAYGROUND}
+    ${HideSection} ${ARDUINO_GEMMA}
+    ${HideSection} ${BLUEFRUIT_LE_MICRO}
+  ${EndIf}
+FunctionEnd


### PR DESCRIPTION
Here's a suggested enhancement to the NSIS installer script that suppresses installation of the usbser-based drivers on Windows 10. I did try this on Windows 7 and 10 and saw the expected differences in the available drivers list. I did not do an exhaustive regression test to make sure the drivers were or were not installed. Would fix #1.